### PR TITLE
Update plugin for zotero 8 compatibility

### DIFF
--- a/addon/install.rdf
+++ b/addon/install.rdf
@@ -5,7 +5,7 @@
   <Description about="urn:mozilla:install-manifest">
     <em:id>research-navigator@zotero.org</em:id>
     <em:name>Zotero Research Navigator</em:name>
-    <em:version>2.9.9</em:version>
+    <em:version>2.9.3</em:version>
     <em:type>2</em:type>
     <em:creator>Research Navigator Developer</em:creator>
     <em:description>Track research history and enhance note navigation in Zotero</em:description>
@@ -20,7 +20,7 @@
       <Description>
         <em:id>zotero@chnm.gmu.edu</em:id>
         <em:minVersion>6.0</em:minVersion>
-        <em:maxVersion>7.0.*</em:maxVersion>
+        <em:maxVersion>8.0.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     
@@ -29,7 +29,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>6.0</em:minVersion>
-        <em:maxVersion>7.0.*</em:maxVersion>
+        <em:maxVersion>8.0.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_addon_name__",
-  "version": "2.9.9",
+  "version": "2.9.3",
   "description": "__MSG_addon_description__",
   "homepage_url": "https://github.com/YOUR_USERNAME/zotero-research-navigator",
   "author": "YOUR_NAME",
@@ -11,7 +11,7 @@
       "id": "research-navigator@zotero.org",
       "update_url": "https://github.com/YOUR_USERNAME/zotero-research-navigator/releases/latest/download/update.json",
       "strict_min_version": "6.0.27",
-      "strict_max_version": "7.0.*"
+      "strict_max_version": "8.0.*"
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zotero-research-navigator",
-  "version": "2.9.9",
+  "version": "2.9.3",
   "description": "A Zotero plugin for tracking research history and enhanced note navigation",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
Update plugin version to 2.9.3 and extend Zotero compatibility to 8.0.*.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec85a005-63c9-47de-9dd9-b7597ab107e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec85a005-63c9-47de-9dd9-b7597ab107e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

